### PR TITLE
dwi2fod step added

### DIFF
--- a/example_mrtrix_script_cc400_ifod2act5Mfsl.sh
+++ b/example_mrtrix_script_cc400_ifod2act5Mfsl.sh
@@ -8,6 +8,7 @@ regimg=${diffdir}/nodif_brain_mask.nii.gz
 mrconvert $diffdir/data.nii.gz DWI.mif -fslgrad $diffdir/bvecs $diffdir/bvals -datatype float32 -stride 0,0,0,1 -quiet -force
 dwibiascorrect DWI.mif DWI_bc.mif -ants -bias DWI_biasfield.mif -mask $diffdir/nodif_brain_mask.nii.gz  -force
 dwi2response dhollander DWI_bc.mif RF_wm_dhollander.txt RF_gm_dhollander.txt RF_csf_dhollander.txt -voxels RF_voxels_dhollander.mif  -force
+dwi2fod msmt_csd DWI_bc.mif RF_wm_dhollander.txt RF_wm_dhollander.mif RF_gm_dhollander.txt RF_gm_dhollander.mif RF_csf_dhollander.txt RF_csf_dhollander.mif -mask $diffdir/nodif_brain_mask.nii.gz
 
 #Make 5TT tissue model using FSL FAST, resampled to diffusion volume space
 5ttgen fsl ${INPUTDIR}/T1w/T1w_acpc_dc_restore.nii.gz 5TT_fsl_T1space.mif -mask ${INPUTDIR}/T1w/T1w_acpc_dc_restore_brain.nii.gz -nocrop -force


### PR DESCRIPTION
Dear Zijin Gu,
Thanks a lot for sharing your connectome pipeline. I've a question: how do you obtain the **RF_wm_dhollander.mif** file before the tckgen step?

https://github.com/zijin-gu/scfc-coupling/blob/2133e95731d4689ca7ca0f685c7bfe13d9d963aa/example_mrtrix_script_cc400_ifod2act5Mfsl.sh#L33

In the present pull request I added the dwi2fod step but please let me know if I am right

Best,
Diego